### PR TITLE
Add &'static str to Value enum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,15 +23,19 @@ pub enum Value {
 
     /// Boolean value.
     Bool(bool),
+
+    /// &'static str value
+    Str(&'static str),
 }
 
-impl ToString for Value {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for Value {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Value::String(s) => s!(s),
-            Value::Int(i) => s!(i),
-            Value::Float(f) => s!(f),
-            Value::Bool(b) => s!(b),
+            Value::String(s) => write!(f, "{}", s),
+            Value::Int(i) => write!(f, "{}", i),
+            Value::Float(n) => write!(f, "{}", n),
+            Value::Bool(b) => write!(f, "{}", b),
+            Value::Str(s) => write!(f, "{}", s),
         }
     }
 }


### PR DESCRIPTION
Hi,

I recently replaced `strfmt` with `figura` for formatting dynamic strings, mainly because it allows the formatting variables (key in the hashmap) to be `'&static str` (getting rid of all the `to_string()` calls), but also because I liked `figura` more than `strfmt`.

But I also found use for the &'static str type in the Value enum, so I forked and added it. Clippy then told me to replace the `ToString` impl with an implementation of `Display`, so that is what I ended up with:
```rust
/// A simple value type used in templating context.
#[derive(Debug, Clone, PartialEq, PartialOrd)]
pub enum Value {
    /// String value.
    String(String),

    /// Integer value.
    Int(i64),

    /// Floating-point value.
    Float(f64),

    /// Boolean value.
    Bool(bool),

    /// &'static str value
    Str(&'static str),
}

impl std::fmt::Display for Value {
    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
        match self {
            Value::String(s) => write!(f, "{}", s),
            Value::Int(i) => write!(f, "{}", i),
            Value::Float(n) => write!(f, "{}", n),
            Value::Bool(b) => write!(f, "{}", b),
            Value::Str(s) => write!(f, "{}", s),
        }
    }
}

```
What do you think?

